### PR TITLE
Adding docker support + some documentation fixes/additions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: mathiasvda/logseq-export-rdf:latest
+          tags: mathiasvda/logseq-rdf-export:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
 
@@ -15,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: "zulu"
           java-version: 17
 
       - name: Set up Clojure
@@ -29,4 +28,22 @@ jobs:
       - name: Check outdated dependencies
         uses: liquidz/antq-action@main
         with:
-          excludes: 'clojure/brew-install'
+          excludes: "clojure/brew-install"
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: mathiasvda/logseq-export-rdf:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:24-slim-bullseye
+RUN apt update && apt remove -y cmdtest && apt install -y npm curl ca-certificates gnupg
+
+# Install Clojure
+RUN curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh && chmod +x linux-install.sh && ./linux-install.sh 
+
+# Install Babashka
+RUN ["/bin/bash", "-c", "bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)"]
+
+# Install Node.js (version 14 or higher)
+ENV NODE_MAJOR=20  
+RUN mkdir -p /etc/apt/keyrings  
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt update && apt install nodejs -y
+
+WORKDIR /logseq-rdf-export
+COPY . /logseq-rdf-export
+RUN npm install -g yarn
+RUN yarn install
+RUN yarn global add /logseq-rdf-export
+RUN logseq-rdf-export || true
+
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ run as a [CLI](#cli).
 
 By default, this action is configured to export the portion of your Logseq graph that:
 
-* has class pages with properties `type:: [[Class]]`
-* has property pages with properties `type:: [[Property]]`
-* has pages with properties `type:: [[X]]` where X are pages with `type:: [[Class]]`
+- has class pages with properties `type:: [[Class]]`
+- has property pages with properties `type:: [[Property]]`
+- has pages with properties `type:: [[X]]` where X are pages with `type:: [[Class]]`
 
 For an example of such a graph, see https://github.com/logseq/docs. If you would like
 to organize your graph differently, you can [configure it](#configuration).
@@ -23,7 +23,7 @@ to organize your graph differently, you can [configure it](#configuration).
 To setup this action, add the file `.github/workflows/ci.yml` to your graph's
 github repository with the following content:
 
-``` yaml
+```yaml
 on: [push]
 
 jobs:
@@ -70,7 +70,8 @@ Since this action produces a valid RDF file, it is easy to save this file for
 later usage using [upload-artifact](https://github.com/actions/upload-artifact):
 
 ```yaml
-...
+
+---
 - name: Export graph as RDF
   uses: logseq/rdf-export@main
   with:
@@ -95,6 +96,7 @@ $ yarn global add $PWD
 ```
 
 Then use it from any logseq graph directory!
+
 ```sh
 $ logseq-rdf-export docs.ttl
 Parsing 301 files...
@@ -104,7 +106,7 @@ Writing 295 triples to file docs.ttl
 
 ## Configuration
 
-To configure how and what is exported to RDF, create a `.export-rdf/config.edn`
+To configure how and what is exported to RDF, create a `.rdf-export/config.edn`
 file in your graph's directory. It's recommended to configure the `:base-url`
 key so that urls point to your Logseq graph. To configure what is exported,
 knowledge of [advanced
@@ -120,9 +122,11 @@ library](https://github.com/logseq/logseq/tree/master/deps/graph-parser) to expo
 from its database.
 
 ## LICENSE
+
 See LICENSE.md
 
 ## Additional Links
-* https://github.com/logseq/graph-validator - Github action that this one is modeled after
-* https://github.com/rdfjs/N3.js - Library that handles the rdf exporting
-* https://github.com/logseq/docs - Logseq graph that uses this action
+
+- https://github.com/logseq/graph-validator - Github action that this one is modeled after
+- https://github.com/rdfjs/N3.js - Library that handles the rdf exporting
+- https://github.com/logseq/docs - Logseq graph that uses this action

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a [github action](https://github.com/features/actions) to export a
 configurable portion of a Logseq graph to [RDF](https://www.w3.org/RDF/). Some
 basic validation is also done on the exported rdf file. This action can also be
-run as a [CLI](#cli).
+run as a [CLI](#cli) or using [Docker](#docker).
 
 ## Usage
 
@@ -70,7 +70,6 @@ Since this action produces a valid RDF file, it is easy to save this file for
 later usage using [upload-artifact](https://github.com/actions/upload-artifact):
 
 ```yaml
-
 ---
 - name: Export graph as RDF
   uses: logseq/rdf-export@main
@@ -102,6 +101,16 @@ $ logseq-rdf-export docs.ttl
 Parsing 301 files...
 ...
 Writing 295 triples to file docs.ttl
+```
+
+### Docker
+
+A docker image is available on [Dockerhub](https://hub.docker.com/r/mathiasvda/logseq-rdf-export)
+
+Example usage:
+
+```sh
+$ docker run -it -v <path-to-logseq-graph-directory>:/data /mathiasvda/logseq-rdf-export logseq-rdf-export docs.ttl
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -113,6 +113,43 @@ Example usage:
 $ docker run -it -v <path-to-logseq-graph-directory>:/data /mathiasvda/logseq-rdf-export logseq-rdf-export docs.ttl
 ```
 
+### Gitlab
+
+[GitLab](https://gitlab.com/) also allows to automate actions, similar to GitHub. Below is an example [.gitlab-ci.yml](https://docs.gitlab.com/ee/ci/) file that uses the Docker image of logseq-export-rdf. The example also includes a step on how to publish the logseq documentation to GitLab pages using the [logseq-publish-spa](https://github.com/logseq/publish-spa) library.
+
+```yml
+stages:
+  - rdf
+  - pages
+
+rdf:
+  image:
+    name: mathiasvda/logseq-rdf-export
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  stage: rdf
+  script:
+    - logseq-rdf-export notes.ttl
+  artifacts:
+    paths:
+      - notes.ttl
+
+pages:
+  image:
+    name: ghcr.io/l-trump/logseq-publish-spa:alpine
+    entrypoint: ["/bin/sh", "-c"]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  stage: pages
+  environment: live
+  script:
+    - mkdir -p public
+    - node /opt/logseq-publish-spa/publish_spa.mjs $CI_PROJECT_DIR/public --static-directory /opt/logseq-static --directory $CI_PROJECT_DIR --theme-mode $THEME --accent-color $ACCENT_COLOR
+  artifacts:
+    paths:
+      - public
+```
+
 ## Configuration
 
 To configure how and what is exported to RDF, create a `.rdf-export/config.edn`


### PR DESCRIPTION
Hello, I'm a fan of rdf-export!

This MR contains a dockerfile and changes to the github actions to automate deployment. 

It also contains additional documentation on how to use the docker image + a fix for an issue that I discovered in the readme file (for the config file location). 

I currently host a dockerimage on dockerhub for this tool, but if you are going to support it, then I will remove the image. In that case, the documentation will also need to be adapted to point to the official docker image. 

In order for the github action to work, two secrets need to be added here: https://github.com/logseq/rdf-export/settings/secrets/actions

- DOCKER_PASSWORD
- DOCKER_USERNAME
